### PR TITLE
CI & README standardization

### DIFF
--- a/.github/workflows/build-humble.yml
+++ b/.github/workflows/build-humble.yml
@@ -1,4 +1,4 @@
-name: Humble Build Main
+name: Humble
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/build-jazzy.yml
+++ b/.github/workflows/build-jazzy.yml
@@ -1,4 +1,4 @@
-name: Jazzy Build Main
+name: Jazzy
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/build-kilted.yml
+++ b/.github/workflows/build-kilted.yml
@@ -1,4 +1,4 @@
-name: Kilted Build Main
+name: Kilted
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/build-lyrical.yml
+++ b/.github/workflows/build-lyrical.yml
@@ -1,4 +1,4 @@
-name: Lyrical Build Main
+name: Lyrical
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/build-rolling.yml
+++ b/.github/workflows/build-rolling.yml
@@ -1,4 +1,4 @@
-name: Rolling Build Main
+name: Rolling
 on:
   workflow_dispatch:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # rsl_drive_sdk 
 
-[![Rolling](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-rolling.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-rolling.yml)
-[![Lyrical](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-lyrical.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-lyrical.yml)
-[![Kilted](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-kilted.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-kilted.yml)
-[![Jazzy](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-jazzy.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-jazzy.yml)
 [![Humble](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-humble.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-humble.yml)
+[![Jazzy](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-jazzy.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-jazzy.yml)
+[![Kilted](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-kilted.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-kilted.yml)
+[![Lyrical](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-lyrical.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-lyrical.yml)
+[![Rolling](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-rolling.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-rolling.yml)
 
 
 Software Development Kit for all RSL drives.\

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # rsl_drive_sdk 
 
-[![Rolling Build Main](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-rolling.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-rolling.yml)
-[![Lyrical Build Main](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-lyrical.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-lyrical.yml)
-[![Kilted Build Main](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-kilted.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-kilted.yml)
-[![Jazzy Build Main](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-jazzy.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-jazzy.yml)
-[![Humble Build Main](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-humble.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-humble.yml)
+[![Rolling](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-rolling.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-rolling.yml)
+[![Lyrical](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-lyrical.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-lyrical.yml)
+[![Kilted](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-kilted.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-kilted.yml)
+[![Jazzy](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-jazzy.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-jazzy.yml)
+[![Humble](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-humble.yml/badge.svg)](https://github.com/Duatic/rsl_drive_sdk/actions/workflows/build-humble.yml)
 
 
 Software Development Kit for all RSL drives.\


### PR DESCRIPTION
Standardizes CI workflows and README badges to the current Duatic convention (reference: `duatic_duarover`).

**Changes in this repo:**
- fix(ci): simplify workflow names

Part of a workspace-wide CI/README cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)